### PR TITLE
Fixed NPC turn rate breaking monsters by going through a changelevel

### DIFF
--- a/dlls/monsters.cpp
+++ b/dlls/monsters.cpp
@@ -2540,18 +2540,16 @@ float CBaseMonster::ChangeYaw ( int yawSpeed )
 	if (current != ideal)
 	{
 		if( m_flLastYawTime == 0 )
-		{
 			m_flLastYawTime = gpGlobals->time - gpGlobals->frametime;
-		}
 
 		float delta = gpGlobals->time - m_flLastYawTime;
 
 		m_flLastYawTime = gpGlobals->time;
 
-		if( delta > 0.25 )
+		if (delta > 0.25 || delta <= 0)
 			delta = 0.25;
 
-		speed = yawSpeed * delta * 2;
+		speed = (float)yawSpeed * delta * 2;
 
 		move = ideal - current;
 


### PR DESCRIPTION
fixes this: https://streamable.com/rfj2km

cc @hobokenn

based on testing and this output (before fixing), the added delta check on should be enough for this to work through changelevels and stop the spinnin' zombies:

```
| m_flLastYawTime = 14.108806 |  gpGlobals->time = 4.093598 | timedelta = -10.015208 | speed = -2403.649864
| m_flLastYawTime = 4.092931 |  gpGlobals->time = 4.193598 | timedelta = 0.100667 | speed = 24.160080
| m_flLastYawTime = 4.192708 |  gpGlobals->time = 4.293598 | timedelta = 0.100890 | speed = 24.213524
| m_flLastYawTime = 4.292793 |  gpGlobals->time = 4.393598 | timedelta = 0.100804 | speed = 24.193039
| m_flLastYawTime = 5.192631 |  gpGlobals->time = 5.293597 | timedelta = 0.100966 | speed = 24.231834
```