### PR TITLE
Fixed fastfire fix breaking weapon firing

### DIFF
--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -117,7 +117,7 @@ TYPEDESCRIPTION	CBasePlayer::m_playerSaveData[] =
 	DEFINE_FIELD( CBasePlayer, m_pTank, FIELD_EHANDLE ),
 	DEFINE_FIELD( CBasePlayer, m_iHideHUD, FIELD_INTEGER ),
 	DEFINE_FIELD( CBasePlayer, m_iFOV, FIELD_INTEGER ),
-	DEFINE_FIELD( CBasePlayer, m_flNextAttack, FIELD_TIME ),
+	DEFINE_FIELD( CBasePlayer, m_flNextAttack, FIELD_FLOAT ),
 	
 	//DEFINE_FIELD( CBasePlayer, m_fDeadTime, FIELD_FLOAT ), // only used in multiplayer games
 	//DEFINE_FIELD( CBasePlayer, m_fGameHUDInitialized, FIELD_INTEGER ), // only used in multiplayer games


### PR DESCRIPTION
Fixed fastfire breaking weapon firing when gpGlobals->time is lower on map A than it is on map B after changelevel chain:
start A ---> go B ---> go back A.

oops