### PR TITLE
Fixed grunts duping ammo on gibbing, revert fastfire

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ New:
 - Fixed duplicating weapons by saveloading.
 - Fixed NPCs rotating slower when game is running at higher FPS.
 - Fixed explosions going through walls in certain cases.
+- Fixed ladderboosting.
 
 Half Life 1 SDK LICENSE
 ======================

--- a/dlls/client.cpp
+++ b/dlls/client.cpp
@@ -519,7 +519,12 @@ void ClientCommand( edict_t *pEntity )
 	}
 	else if ( FStrEq(pcmd, "fullupdate" ) )
 	{
-		GetClassPtr((CBasePlayer *)pev)->ForceClientDllUpdate(); 
+		GetClassPtr((CBasePlayer *)pev)->ForceClientDllUpdate();
+		GetClassPtr((CBasePlayer *)pev)->m_iClientFOV = -1; //rofi - this forces clip ammo update on demo record
+		for (int i=0; i < MAX_AMMO_SLOTS;i++)
+		{
+			GetClassPtr((CBasePlayer *)pev)->m_rgAmmoLast[i] = -1; //rofi - same as above, but with carried ammo for all weapons
+		}
 	}
 	else if ( FStrEq(pcmd, "give" ) )
 	{

--- a/dlls/hgrunt.cpp
+++ b/dlls/hgrunt.cpp
@@ -838,25 +838,28 @@ void CHGrunt :: Shotgun ( void )
 
 void CHGrunt :: Killed( entvars_t *pevAttacker, int iGib )
 {
-	CSquadMonster :: Killed ( pevAttacker, iGib );
 	Vector	vecGunPos;
 	Vector	vecGunAngles;
 
 	GetAttachment( 0, vecGunPos, vecGunAngles );
 
-	// now spawn a gun.
-	if (FBitSet( pev->weapons, HGRUNT_SHOTGUN ))
+	if (!ShouldGibMonster(iGib)) // If we're gibbing, we 'throw' a gun in Gibbed(), not here.
 	{
-		DropItem( "weapon_shotgun", vecGunPos, vecGunAngles );
+		// now spawn a gun.
+		if (FBitSet( pev->weapons, HGRUNT_SHOTGUN ))
+		{
+			DropItem( "weapon_shotgun", vecGunPos, vecGunAngles );
+		}
+		else
+		{
+			DropItem( "weapon_9mmAR", vecGunPos, vecGunAngles );
+		}
+		if (FBitSet( pev->weapons, HGRUNT_GRENADELAUNCHER ))
+		{
+			DropItem( "ammo_ARgrenades", BodyTarget( pev->origin ), vecGunAngles );
+		}
 	}
-	else
-	{
-		DropItem( "weapon_9mmAR", vecGunPos, vecGunAngles );
-	}
-	if (FBitSet( pev->weapons, HGRUNT_GRENADELAUNCHER ))
-	{
-		DropItem( "ammo_ARgrenades", BodyTarget( pev->origin ), vecGunAngles );
-	}
+	CSquadMonster :: Killed ( pevAttacker, iGib );
 }
 
 //=========================================================

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -117,7 +117,6 @@ TYPEDESCRIPTION	CBasePlayer::m_playerSaveData[] =
 	DEFINE_FIELD( CBasePlayer, m_pTank, FIELD_EHANDLE ),
 	DEFINE_FIELD( CBasePlayer, m_iHideHUD, FIELD_INTEGER ),
 	DEFINE_FIELD( CBasePlayer, m_iFOV, FIELD_INTEGER ),
-	DEFINE_FIELD( CBasePlayer, m_flNextAttack, FIELD_FLOAT ),
 	
 	//DEFINE_FIELD( CBasePlayer, m_fDeadTime, FIELD_FLOAT ), // only used in multiplayer games
 	//DEFINE_FIELD( CBasePlayer, m_fGameHUDInitialized, FIELD_INTEGER ), // only used in multiplayer games
@@ -3084,7 +3083,7 @@ int CBasePlayer::Restore( CRestore &restore )
 	// HACK:	This variable is saved/restored in CBaseMonster as a time variable, but we're using it
 	//			as just a counter.  Ideally, this needs its own variable that's saved as a plain float.
 	//			Barring that, we clear it out here instead of using the incorrect restored time value.
-	// m_flNextAttack = UTIL_WeaponTimeBase();
+	m_flNextAttack = UTIL_WeaponTimeBase();
 #endif
 
 	return status;

--- a/pm_shared/pm_shared.c
+++ b/pm_shared/pm_shared.c
@@ -2163,13 +2163,6 @@ void PM_LadderMove( physent_t *pLadder )
 			right += flSpeed;
 		}
 
-		float speed = hypot(right, forward);
-		if (speed > MAX_CLIMB_SPEED)
-		{
-			right *= 0.5f;
-			forward *= 0.5f;
-		}
-
 		if ( pmove->cmd.buttons & IN_JUMP )
 		{
 			pmove->movetype = MOVETYPE_WALK;
@@ -2220,6 +2213,10 @@ void PM_LadderMove( physent_t *pLadder )
 					VectorMA( pmove->velocity, MAX_CLIMB_SPEED, trace.plane.normal, pmove->velocity );
 				}
 				//pev->velocity = lateral - (CrossProduct( trace.vecPlaneNormal, perp ) * normal);
+
+				// Ladderspeeding fix: just cap the z-component of the velocity
+				if (abs(pmove->velocity[2]) > MAX_CLIMB_SPEED)
+						pmove->velocity[2] *= MAX_CLIMB_SPEED / abs(pmove->velocity[2]);
 			}
 			else
 			{

--- a/pm_shared/pm_shared.c
+++ b/pm_shared/pm_shared.c
@@ -2215,8 +2215,8 @@ void PM_LadderMove( physent_t *pLadder )
 				//pev->velocity = lateral - (CrossProduct( trace.vecPlaneNormal, perp ) * normal);
 
 				// Ladderspeeding fix: just cap the z-component of the velocity
-				if (abs(pmove->velocity[2]) > MAX_CLIMB_SPEED)
-						pmove->velocity[2] *= MAX_CLIMB_SPEED / abs(pmove->velocity[2]);
+				if (fabs(pmove->velocity[2]) > MAX_CLIMB_SPEED)
+						pmove->velocity[2] *= MAX_CLIMB_SPEED / fabs(pmove->velocity[2]);
 			}
 			else
 			{

--- a/pm_shared/pm_shared.c
+++ b/pm_shared/pm_shared.c
@@ -2163,6 +2163,13 @@ void PM_LadderMove( physent_t *pLadder )
 			right += flSpeed;
 		}
 
+		float speed = hypot(right, forward);
+		if (speed > MAX_CLIMB_SPEED)
+		{
+			right *= 0.5f;
+			forward *= 0.5f;
+		}
+
 		if ( pmove->cmd.buttons & IN_JUMP )
 		{
 			pmove->movetype = MOVETYPE_WALK;


### PR DESCRIPTION
Fastfire breaks client side weapon stuff, for some reason, so I'm reverting since cba to put any more effort into fixing a trick that isn't used in RTA runs.

Draft since it's pending for a test by Muty and myself.